### PR TITLE
Added Symfony 4 support

### DIFF
--- a/behat.yml
+++ b/behat.yml
@@ -1,23 +1,23 @@
 default:
-  autoload: [ %paths.base%/tests/behat/bootstrap ]
+  autoload: [ "%paths.base%/tests/behat/bootstrap" ]
   suites:
     default:
-      paths: [ %paths.base%/tests/behat/features ]
+      paths: [ "%paths.base%/tests/behat/features" ]
       contexts:
         - IntegratedExperts\BehatPhpServer\PhpServerContext:
           -
-            docroot: %paths.base%/tests/behat/features/fixtures
+            docroot: "%paths.base%/tests/behat/features/fixtures"
         - IntegratedExperts\BehatScreenshotExtension\Context\ScreenshotContext
         - FeatureContext:
           -
-            screenshot_dir: %paths.base%/screenshots
+            screenshot_dir: "%paths.base%/screenshots"
   extensions:
     Behat\MinkExtension:
       goutte: ~
-      files_path: %paths.base%/tests/behat/features/fixtures
+      files_path: "%paths.base%/tests/behat/features/fixtures"
       selenium2: ~
       browser_name: chrome
     IntegratedExperts\BehatScreenshotExtension:
-      dir: %paths.base%/screenshots
+      dir: "%paths.base%/screenshots"
       fail: true
       purge: true

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "behat/mink-extension": "~v2.2",
     "behat/mink-goutte-driver": "*",
     "behat/mink-selenium2-driver": "*",
-    "symfony/finder": "^3.2"
+    "symfony/finder": "^3.2|^4.0"
   },
   "require-dev": {
     "behat/mink": "~1.5",


### PR DESCRIPTION
I have fixed an error that has been throwing before Behat test execution:

> The reserved indicator "%" cannot start a plain scalar; you need to quote the scalar at line 2 (near "autoload: [ %paths.base%/tests/behat/bootstrap ]").