### PR TITLE
Minor edits in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,13 +43,13 @@ In your feature:
 
 - `dir:` `path/to/dir`
 
-  Path to directory to save scereenshots. Directory structure will be created if the directory does not exist.
+  Path to directory to save screenshots. Directory structure will be created if the directory does not exist.
   
-- `fail:` `true` or `false`
+- `fail:` `true` or `false` (default `false`)
   
   Prefix failed screenshots with 'fail_' string. Useful to distinguish failed and intended screenshots.
       
-- `purge:` `false` or `false`
+- `purge:` `true` or `false` (default `false`)
   
   Remove all files from the screenshots directory on each test run. Useful during debugging of tests.
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ default:
         - FeatureContext
   extensions:
     IntegratedExperts\BehatScreenshotExtension:
-      dir: %paths.base%/screenshots
+      dir: '%paths.base%/screenshots'
       fail: true
       purge: false
 ```


### PR DESCRIPTION
1) a few minor edits
2) I had to quote the screenshots dir reference in behat.yml - otherwise I get:

```
[Symfony\Component\Yaml\Exception\ParseException] 
The reserved indicator "%" cannot start a plain scalar; you need to quote the scalar at line 1208 (near "dir: %paths.base%/screenshots").
```
